### PR TITLE
Fix macOS 10.12 having `clock_gettime`

### DIFF
--- a/src/time.c
+++ b/src/time.c
@@ -10,8 +10,10 @@
 #include <sys/time.h>
 #endif
 
+#ifndef HAVE_CLOCK_GETTIME
 #ifdef __APPLE__
 #include "time_osx.h"
+#endif
 #endif
 
 #include "compat.h"


### PR DESCRIPTION
See https://github.com/Homebrew/homebrew-core/issues/1957 for similar issues.